### PR TITLE
return the text of the selected option instead of its value

### DIFF
--- a/lib/corner_stones/form/fields/select_field.rb
+++ b/lib/corner_stones/form/fields/select_field.rb
@@ -21,7 +21,7 @@ module CornerStones
         end
 
         def get
-          @field.value
+          @field.find("option[value='#{@field.value}']").text
         end
       end
     end

--- a/lib/corner_stones/form/with_inline_errors.rb
+++ b/lib/corner_stones/form/with_inline_errors.rb
@@ -17,7 +17,7 @@ module CornerStones
           error = container.all('.help-inline').first
 
           { 'Field' => label && label.text,
-            'Value' => input && input.value,
+            'Value' => input && FieldSelector.find_by_element(input).get,
             'Error' => error && error.text }
         end
       end

--- a/spec/integration/corner_stones/form_spec.rb
+++ b/spec/integration/corner_stones/form_spec.rb
@@ -101,7 +101,7 @@ describe CornerStones::Form do
 
     subject.attributes.must_equal('Title' => 'Domain Driven Design',
                                   'Password' => 'secret',
-                                  'Author' => '2',
+                                  'Author' => 'Eric Evans',
                                   'Body' => '...',
                                   'File' => 'spec/files/hadoken.png',
                                   'Checkbox' => '1')
@@ -156,7 +156,7 @@ HTML
         HTML
 
         it 'assembles the errors into a hash' do
-          subject.errors.must_equal([{"Field" => "Author", "Value" => "1", "Error" => "The author is not active"},
+          subject.errors.must_equal([{"Field" => "Author", "Value" => "Robert C. Martin", "Error" => "The author is not active"},
                                      {"Field" => "Body", "Value" => "...", "Error" => "invalid body"}])
         end
 

--- a/spec/integration/corner_stones/table_form_spec.rb
+++ b/spec/integration/corner_stones/table_form_spec.rb
@@ -69,7 +69,7 @@ HTML
     subject.fill_in_row({'Title' => 'As it is in heaven'}, :with => {'Duration' => '112 min', 'Extras' => 'Special Scenes'})
 
     subject.row('Title' => 'As it is in heaven')['Duration'].must_equal '112 min'
-    subject.row('Title' => 'As it is in heaven')['Extras'].must_equal '2'
+    subject.row('Title' => 'As it is in heaven')['Extras'].must_equal 'Special Scenes'
   end
 
   it 'allows you to submit the form' do
@@ -91,13 +91,13 @@ HTML
 
     subject.row('Title' => 'Pirates of the Carribean', 'Genre' => 'Action')['Actors'].must_equal 'Jonny Depp'
     subject.row('Title' => 'Pirates of the Carribean', 'Genre' => 'Action')['Duration'].must_equal '120 min'
-    subject.row('Title' => 'Pirates of the Carribean', 'Genre' => 'Action')['Extras'].must_equal '1'
+    subject.row('Title' => 'Pirates of the Carribean', 'Genre' => 'Action')['Extras'].must_equal 'No extras'
     subject.row('Title' => 'Pirates of the Carribean', 'Genre' => 'Tragedy')['Actors'].must_equal 'David Hasselhoff'
     subject.row('Title' => 'Pirates of the Carribean', 'Genre' => 'Tragedy')['Duration'].must_equal nil
-    subject.row('Title' => 'Pirates of the Carribean', 'Genre' => 'Tragedy')['Extras'].must_equal '1'
+    subject.row('Title' => 'Pirates of the Carribean', 'Genre' => 'Tragedy')['Extras'].must_equal 'No extras'
     subject.row('Title' => 'As it is in heaven', 'Genre' => 'Comedy')['Actors'].must_equal 'Michael Moore'
     subject.row('Title' => 'As it is in heaven', 'Genre' => 'Comedy')['Duration'].must_equal '108 min'
-    subject.row('Title' => 'As it is in heaven', 'Genre' => 'Comedy')['Extras'].must_equal '2'
+    subject.row('Title' => 'As it is in heaven', 'Genre' => 'Comedy')['Extras'].must_equal 'Special Scenes'
   end
 
   it 'fills the first matching row if the row cannot be uniquely identified' do
@@ -149,7 +149,7 @@ HTML
       subject.fill_in_table(cucumber_table_hashes)
 
       subject.row('Title' => 'Pirates of the Carribean', 'Genre' => 'Tragedy')['Duration'].must_equal '140 min'
-      subject.row('Title' => 'As it is in heaven')['Extras'].must_equal '2'
+      subject.row('Title' => 'As it is in heaven')['Extras'].must_equal 'Special Scenes'
     end
   end
 


### PR DESCRIPTION
It doesn't make sense to return the value of the selected option of a select box. In most cases the value will be an id of an element in the database. Or at least an id to identify some element. You shouldn't use ids in your acceptance tests because this is not what the user sees in his browser. It makes more sense to return the text of the selected option.
