### PR TITLE
explicitly set capybara version

### DIFF
--- a/corner_stones.gemspec
+++ b/corner_stones.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest", '~> 3.3.0'
-  s.add_runtime_dependency "capybara"
-
+  s.add_runtime_dependency "capybara", '~> 1.1.3'
 end


### PR DESCRIPTION
currently corner_stones does not work with capybara 2.0
