### PR TITLE
Functionality to check if a table is empty

### DIFF
--- a/lib/corner_stones/table.rb
+++ b/lib/corner_stones/table.rb
@@ -23,6 +23,10 @@ module CornerStones
       } or raise MissingRowError, "no row with '#{options.inspect}'\n\ngot:#{rows}"
     end
 
+    def empty?
+      rows.empty?
+    end
+
     def rows
       within @scope do
         all('tbody tr').map do |row|

--- a/spec/integration/corner_stones/table_spec.rb
+++ b/spec/integration/corner_stones/table_spec.rb
@@ -82,6 +82,26 @@ describe CornerStones::Table do
     it 'extracts the Capybara-Element for the table row' do
       subject.row('ID' => '1')['Row-Element'].path.must_equal('/html/body/table/tbody/tr[1]')
     end
+
+    it 'the table should be empty' do
+      subject.empty?.must_equal(false)
+    end
+  end
+
+  describe 'tables without rows' do
+    let(:html) { <<-HTML
+      <table class="articles">
+        <tbody>
+        </tbody>
+      </table>
+    HTML
+    }
+
+    subject { CornerStones::Table.new('.articles', :headers => ['Book', 'Author'], :data_selector => 'th,td') }
+
+    it 'the table should be empty' do
+      subject.empty?.must_equal(true)
+    end
   end
 
   describe 'custom tables' do


### PR DESCRIPTION
As a developer I would like to test if a table is empty (doesn't contain any rows).

With the current code I have to do the following:

```
table.rows.should be_empty
```

With this patch I can ask the table if it is empty:

```
table.should be_empty
```
