### PR TITLE
new Table#hashes method to diff against AST::Tables

### DIFF
--- a/lib/corner_stones/table.rb
+++ b/lib/corner_stones/table.rb
@@ -27,6 +27,10 @@ module CornerStones
       rows.empty?
     end
 
+    def hashes
+      rows.map{|row| row.attributes}
+    end
+
     def rows
       within @scope do
         all('tbody tr').map do |row|

--- a/spec/integration/corner_stones/table_spec.rb
+++ b/spec/integration/corner_stones/table_spec.rb
@@ -50,11 +50,7 @@ describe CornerStones::Table do
       expected_data = [{'ID' => '1', 'Title' => 'Clean Code', 'Author' => 'Robert C. Martin'},
                        { 'ID' => '2', 'Title' => 'Domain Driven Design', 'Author' => 'Eric Evans'}]
 
-      subject.rows.map {|r|
-        r.attributes.reject do |key, _value|
-          !expected_data.first.has_key?(key)
-        end
-      }.must_equal(expected_data)
+      subject.hashes.must_equal(expected_data)
     end
 
     it 'a row can be accessed with a single key' do
@@ -123,11 +119,7 @@ describe CornerStones::Table do
                            'Author' => 'Robert C. Martin'},
                          { 'Book' => 'Domain Driven Design',
                            'Author' => 'Eric Evans'}]
-        subject.rows.map {|r|
-          r.attributes.reject do |key, _value|
-            !expected_data.first.has_key?(key)
-          end
-        }.must_equal(expected_data)
+        subject.hashes.must_equal(expected_data)
       end
 
     end
@@ -155,10 +147,8 @@ HTML
 
     it 'ignores empty cells' do
       expected_data = [{'ID' => '1', 'Title' => 'Clean Code', 'Author' => nil}]
-      actual = subject.rows
 
-      actual = actual.map {|row| row.attributes.reject {|key, _value| !expected_data.first.has_key?(key)}}
-      actual.must_equal(expected_data)
+      subject.hashes.must_equal(expected_data)
     end
   end
 


### PR DESCRIPTION
As a developer I would like to compare the data of a `CornerStones::Table` with the data of a `Cucumber::Ast::Table`.

At the moment I have to do the following:

``` ruby
  table = CornerStones::Table.new("table_selector")

  expected_data = expected_results.hashes

  actual_data = table.rows.map {|row| row.attributes.reject {|key, _value| !expected_data.first.has_key?(key)}}

  actual_data.should == expected_data
```

With this PR I can do:

``` ruby
  table = CornerStones::Table.new("table_selector")

  expected_data = expected_results.hashes

  table.equals?(expected_data).should == true
```
