### PR TITLE
raise OptionNotFound when filling a select with a text for which there is no option.

### DIFF
--- a/lib/corner_stones/form.rb
+++ b/lib/corner_stones/form.rb
@@ -7,6 +7,7 @@ module CornerStones
   class Form
 
     class UnknownFieldError < RuntimeError; end
+    class OptionNotFound < ArgumentError; end
 
     include Capybara::DSL
 

--- a/lib/corner_stones/form/fields/select_field.rb
+++ b/lib/corner_stones/form/fields/select_field.rb
@@ -19,7 +19,14 @@ module CornerStones
             options = @field.all("option")
             selected_option = options.detect {|o| o.text == value}
             selected_option ||= options.detect {|o| o.text.include? value}
-            selected_option.select_option
+            if selected_option
+              selected_option.select_option
+            else
+              raise OptionNotFound, <<-MESSAGE.strip
+The select #{@field['name'].inspect} does not contain an option #{value.inspect}.
+Available options: #{options.map(&:text).inspect}
+              MESSAGE
+            end
           end
         end
 

--- a/spec/integration/corner_stones/form_spec.rb
+++ b/spec/integration/corner_stones/form_spec.rb
@@ -124,6 +124,16 @@ describe CornerStones::Form do
                                   'Tags' => ['Ruby', 'OOP'])
   end
 
+  it 'raises an error when filling a select with text for which there is no option' do
+    e = assert_raises(CornerStones::Form::OptionNotFound) {
+      subject.fill_in_with('Author' => 'Zaphod Beeblebrox')
+    }
+    assert_equal <<-MESSAGE.strip, e.message
+The select "author" does not contain an option "Zaphod Beeblebrox".
+Available options: ["Robert C. Martin", "Eric Evans", "Kent Beck"]
+    MESSAGE
+  end
+
   describe 'form with an unknown field type' do
     let(:html_fixture) {<<-HTML
       <form action="/articles" method="post" class="form-with-errors article-form">


### PR DESCRIPTION
When filling a select with a text for which there is no option, I get:

``` ruby
NoMethodError: undefined method `select_option' for nil:NilClass
```

With this change it will raise a `OptionNotFound` exception, e.g.:

``` ruby
CornerStones::Form::OptionNotFound: The select "author" does not contain an option "Zaphod Beeblebrox".
Available options: ["Robert C. Martin", "Eric Evans", "Kent Beck"]
```
