### PR TITLE
handle embed tables as string and not rows on the same level

### DIFF
--- a/lib/corner_stones/table.rb
+++ b/lib/corner_stones/table.rb
@@ -44,7 +44,7 @@ module CornerStones
 
     def raw_rows
       within @scope do
-        all('tbody tr')
+        all('tbody > tr')
       end
     end
 

--- a/spec/integration/corner_stones/table_spec.rb
+++ b/spec/integration/corner_stones/table_spec.rb
@@ -278,6 +278,35 @@ HTML
       end
     end
 
+    describe "Embedded tables" do
+      let(:html_fixture) { <<-HTML
+        <table class="articles">
+          <thead>
+            <tr>
+              <th>Author</th>
+            </tr>
+          </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <table>
+                    <tr>
+                      <td>Eric</td>
+                      <td>Evans</td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+    HTML
+      }
+
+      it 'handles embed tables as text, if they dont come with their own tbody' do
+        subject.hashes.must_equal [{"Author"=>"Eric Evans"}]
+      end
+    end
+
     describe 'whitespace filter' do
       let(:html_fixture) { <<-HTML
         <table class="articles">


### PR DESCRIPTION
Not sure if embed tables are really ment to result in rows on the same level. IMHO this is not expected behaviour and while forcing it to a string is nether it should fit more expected use cases. 