### PR TITLE
ignore dismiss button of alert message

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,41 @@ tabs.assert_current_tab_is('Main') # verify that the tab 'Main' is active
 
 ### Flash Messages
 
+If you want use default messages (bootstrap 3, classes with .alert-success, .alert-info, .alert-warning, .alert-danger will be interpreted as a flash message).
 ```ruby
-flash = CornerStones::FlashMessages.new
-flash.assert_flash_is_present(:notice, 'Article saved') # verify that a given flash message is present
+flashes = CornerStones::FlashMessages.bootstrap3
+```
+If you use the bootstrap3 initializer the default ignore_selectors will be: [data-dismiss=alert],
+You can add some more using the ```ignore_selectors``` option
+```ruby
+flashes = CornerStones::FlashMessages.new(ignore_selectors: '.my-button-which-closes-the-alert')
+```
+
+If you use the default constructor it the message_types will be: .alert, .notice, .error
+```ruby
+flashes = CornerStones::FlashMessages.new
+```
+
+If you want some custom selectors for the alerts you can call it like this
+```ruby
+flashes = CornerStones::FlashMessages.new(message_types: [:'.my-alert-class-good', :'.my-alert-class-attention'])
+```
+
+Ignore selectors are there for you to make your life easier if you want it to .
+You can define what should be ignored inside the alert to make sure you only get the message of the alert and not a close button or an icon if you have some other things inside your alert.
+Use css selectors to do so:
+```ruby
+flashes = CornerStones::FlashMessages.new(ignore_selectors: '.close-button')
+```
+
+To get all messages you can simply call (more likely to debug than testing, for testing use ```assert_flash_is_present```)
+```ruby
+flashes.messages # => {'alert-info': 'This is an Information'}
+```
+
+To directly assert if a message is present you can call
+```ruby
+flashes.assert_flash_is_present(:'alert-info', 'This is an Information')
 ```
 
 ### Tables

--- a/lib/corner_stones/flash_messages.rb
+++ b/lib/corner_stones/flash_messages.rb
@@ -9,6 +9,12 @@ module CornerStones
       @options = options
     end
 
+    def self.bootstrap3(options = {})
+      ignore_selectors = ['[data-dismiss=alert]']
+      ignore_selectors << Array(options[:ignore_selectors]) if options.has_key?(:ignore_selectors)
+      new({message_types: [:'alert-info', :'alert-success', :'alert-warning', :'alert-danger'], ignore_selectors: ignore_selectors })
+    end
+
     def message(type, text)
       messages[type].detect {|message| message[:text] == text}
     end
@@ -16,7 +22,11 @@ module CornerStones
     def messages
       message_types.inject(Hash.new {|hash, key| hash[key] = []}) do |present_messages, type|
         all(".#{type}").map do |message|
-          present_messages[type] << {:text => message.text}
+          native = message.native.dup
+          Array(@options[:ignore_selectors]).each do |ignore_selector|
+            native.css(ignore_selector).remove
+          end
+          present_messages[type] << {text: native.text.strip}
         end
         present_messages
       end

--- a/spec/integration/corner_stones/flash_messages_spec.rb
+++ b/spec/integration/corner_stones/flash_messages_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'integration/spec_helper'
 
 require 'corner_stones/flash_messages'
@@ -86,7 +87,7 @@ MESSAGE
   describe 'bootstrap 3 messages' do
     let(:html_fixture) { <<-HTML
       <div class="alert alert-info text-center">Article was updated</div>
-      <div class="alert alert-danger text-center">Article fucked up</div>
+      <div class="alert alert-danger text-center">Article failed to update</div>
     HTML
     }
 
@@ -94,7 +95,30 @@ MESSAGE
 
     it 'will find all alert messages also if they are not in a <p>' do
       subject.messages.must_equal(:'alert-info' => [{:text => 'Article was updated'}],
-                                  :'alert-danger' => [{:text => 'Article fucked up'}])
+                                  :'alert-danger' => [{:text => 'Article failed to update'}])
+    end
+
+    subject { CornerStones::FlashMessages.bootstrap3 }
+
+    it 'will fin all bootstrap messages with the bootstrap3 initializer' do
+      subject.messages.must_equal({ :"alert-info"=>[{:text=>"Article was updated"}],
+                                      :"alert-danger"=>[{:text=>"Article failed to update"}]})
+    end
+  end
+
+  describe 'bootstrap 3 messages with dismissible button' do
+    let(:html_fixture) { <<-HTML
+      <div class="alert alert-info text-center"><button type="button" class="close" data-dismiss="alert">×</button>Article was updated</div>
+      <div class="alert alert-danger text-center"><button type="button" class="close" data-dismiss="alert">×</button>Article failed to update</div>
+    HTML
+    }
+
+    subject { CornerStones::FlashMessages.new(message_types: [:'alert-info', :'alert-danger', :'alert-warning'],
+                                              ignore_selectors: '[data-dismiss=alert]')}
+
+    it 'will find all alert messages and ignore the close button text' do
+      subject.messages.must_equal(:'alert-info' => [{:text => 'Article was updated'}],
+                                  :'alert-danger' => [{:text => 'Article failed to update'}])
     end
 
   end


### PR DESCRIPTION
If a bootstrap 3 alert has a close button it will have a `<a>` or a `<button>` inside which has `data-dismiss="alert"` or the class `close`

If corner stones gets the flash message of an alert with a close button it will return the X (close button text) within the text of the flash message.

With this commit corner stones will ignore elements inside an alert which have the data-dismiss="alert" or  class="close" attributes.
